### PR TITLE
[#168862462] Add COOKIE_DOMAIN env var to io-onboarding-pa-api helm chart

### DIFF
--- a/configs/prod.yaml
+++ b/configs/prod.yaml
@@ -48,6 +48,7 @@ ioOnboardingPaApi:
     client_domain: https://pa-onboarding.io.italia.it:443
     client_spid_login_redirection_url: https://pa-onboarding.io.italia.it
     client_spid_success_redirection_url: https://pa-onboarding.io.italia.it/dashboard
+    cookie_domain: .pa-onboarding.io.italia.it
     saml_callback_url: "https://api.pa-onboarding.io.italia.it/assertion-consumer-service"
     spid_testenv_url: "https://spid-testenv.io.italia.it"
 

--- a/io-onboarding-pa-api/templates/deployment.yaml
+++ b/io-onboarding-pa-api/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: "{{ .Values.ioOnboardingPaApi.env.client_spid_login_redirection_url }}"
             - name: CLIENT_SPID_SUCCESS_REDIRECTION_URL
               value: "{{ .Values.ioOnboardingPaApi.env.client_spid_success_redirection_url }}"
+            - name: COOKIE_DOMAIN
+              value: "{{ .Values.ioOnboardingPaApi.env.cookie_domain }}"
             - name: SAML_ACCEPTED_CLOCK_SKEW_MS
               value: "{{ .Values.ioOnboardingPaApi.env.saml_accepted_clock_skew_ms }}"
             - name: SAML_ATTRIBUTE_CONSUMING_SERVICE_INDEX

--- a/io-onboarding-pa-api/values.yaml
+++ b/io-onboarding-pa-api/values.yaml
@@ -31,6 +31,7 @@ ioOnboardingPaApi:
     client_spid_error_redirection_url: /error.html
     client_spid_login_redirection_url: https://pa-onboarding.dev.io.italia.it
     client_spid_success_redirection_url: https://pa-onboarding.dev.io.italia.it/dashboard
+    cookie_domain: .pa-onboarding.dev.io.italia.it
     saml_accepted_clock_skew_ms: "-1"
     saml_attribute_consuming_service_index: "0"
     saml_callback_url: "https://api.pa-onboarding.dev.io.italia.it/assertion-consumer-service"


### PR DESCRIPTION
This PR aims to add to the io-onboarding-pa-api helm chart the new `COOKIE_DOMAIN` env var, which is now required after merging teamdigitale/io-onboarding-pa-api#35.