### PR TITLE
[#169810475] Add ARSS env vars to io-onboarding-pa-api helm chart

### DIFF
--- a/io-onboarding-pa-api/templates/deployment.yaml
+++ b/io-onboarding-pa-api/templates/deployment.yaml
@@ -91,6 +91,22 @@ spec:
               value: "{{ .Values.ioOnboardingPaApi.env.email_sender }}"
             - name: INDICEPA_ADMINISTRATIONS_URL
               value: "{{ .Values.ioOnboardingPaApi.env.indicepa_administrations_url }}"
+            - name: ARSS_WSDL_URL
+              value: "{{ .Values.ioOnboardingPaApi.env.arss_wsdl_url }}"
+            - name: ARSS_IDENTITY_OTP_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: io-onboarding-pa-api-secrets
+                  key: arss-identity-otp-pwd
+            - name: ARSS_IDENTITY_TYPE_OTP_AUTH
+              value: "{{ .Values.ioOnboardingPaApi.env.arss_identity_type_otp_auth }}"
+            - name: ARSS_IDENTITY_USER
+              value: "{{ .Values.ioOnboardingPaApi.env.arss_identity_user }}"
+            - name: ARSS_IDENTITY_USER_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: io-onboarding-pa-api-secrets
+                  key: arss-identity-user-pwd
 
           ports:
             - name: onboard-pa-api

--- a/io-onboarding-pa-api/values.yaml
+++ b/io-onboarding-pa-api/values.yaml
@@ -52,6 +52,9 @@ ioOnboardingPaApi:
     email_smtp_secure: "true"
     email_sender: "portaleonboarding@gmail.com"
     indicepa_administrations_url: "https://raw.githubusercontent.com/teamdigitale/io-onboarding-pa-api/master/development-data/administrations.txt"
+    arss_wsdl_url: "https://arss.demo.firma-automatica.it/ArubaSignService/ArubaSignService?wsdl"
+    arss_identity_type_otp_auth: "demoprod"
+    arss_identity_user: "titolare_rem"
 
   secrets:
     azureKeyvaultName: io-dev-keyvault


### PR DESCRIPTION
This PR aims to add to the helm-charts of io-onboarding-pa-api the required environment variables to configure the Aruba Remote Signature Service.