### PR TITLE
rename postgresql variables

### DIFF
--- a/io-onboarding-pa-api/templates/deployment.yaml
+++ b/io-onboarding-pa-api/templates/deployment.yaml
@@ -29,13 +29,13 @@ spec:
           image: "{{ .Values.global.registry }}{{ .Values.ioOnboardingPaApi.images.backend.repository }}:{{ tpl .Values.ioOnboardingPaApi.images.backend.tag . }}"
           imagePullPolicy: {{ .Values.ioOnboardingPaApi.images.pullPolicy }}
           env:
-            - name: POSTGRES_HOST
-              value: "{{ .Values.ioOnboardingPaApi.env.postgres_host }}"
-            - name: POSTGRES_DB
-              value: "{{ .Values.ioOnboardingPaApi.env.postgres_db }}"
-            - name: POSTGRES_USER
-              value: "{{ .Values.ioOnboardingPaApi.env.postgres_user }}"
-            - name: POSTGRES_PASSWORD
+            - name: POSTGRESQL_HOST
+              value: "{{ .Values.ioOnboardingPaApi.env.postgresql_host }}"
+            - name: POSTGRESQL_DATABASE
+              value: "{{ .Values.ioOnboardingPaApi.env.postgresql_database }}"
+            - name: POSTGRESQL_USERNAME
+              value: "{{ .Values.ioOnboardingPaApi.env.postgresql_username }}"
+            - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: io-onboarding-pa-api-secrets

--- a/io-onboarding-pa-api/values.yaml
+++ b/io-onboarding-pa-api/values.yaml
@@ -33,9 +33,9 @@ ioOnboardingPaApi:
     client_spid_success_redirection_url: https://pa-onboarding.dev.io.italia.it/dashboard
     cookie_domain: .dev.io.italia.it
     node_env: development
-    postgres_host: io-onboarding-pa-api-postgresql
-    postgres_db: io-onboarding-pa-api
-    postgres_user: io-onboarding-pa-api
+    postgresql_host: io-onboarding-pa-api-postgresql
+    postgresql_database: io-onboarding-pa-api
+    postgresql_username: io-onboarding-pa-api
     saml_accepted_clock_skew_ms: "-1"
     saml_attribute_consuming_service_index: "0"
     saml_callback_url: "https://api.pa-onboarding.dev.io.italia.it/assertion-consumer-service"


### PR DESCRIPTION
since we now use the bitnami release into our docker-compose file, I've renamed the environment varialbes to match the ones in https://github.com/bitnami/bitnami-docker-postgresql#creating-a-database-user-on-first-run