### PR TITLE
[#170532139] Enable ProxyFix in the spid-testenv config

### DIFF
--- a/spid-testenv/values.yaml
+++ b/spid-testenv/values.yaml
@@ -116,6 +116,9 @@ spidTestenv:
 
       # Disable new users
       can_add_user: false
+      
+      # Enable ProxyFix
+      behind_reverse_proxy: true
 
     idpCrt: |
       -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
This setting is required if the IDP is behind a reverse proxy.